### PR TITLE
Changed AuthnContext (and handler) and added integration tests for agents

### DIFF
--- a/packages/service/config/common.json
+++ b/packages/service/config/common.json
@@ -22,6 +22,15 @@
                 {
                   "@type": "HttpHandlerController",
                   "label": "Static Id Document Controller",
+                  "preResponseHandler": {
+                    "@type": "HttpSequenceContextHandler",
+                    "contextHandlers": [
+                      {
+                        "@type": "AuthnContextHandler",
+                        "strict": false
+                      }
+                    ]
+                  },
                   "routes": [
                     {
                       "@type": "HttpHandlerRoute",

--- a/packages/service/config/common.json
+++ b/packages/service/config/common.json
@@ -21,7 +21,7 @@
               "handlerControllerList": [
                 {
                   "@type": "HttpHandlerController",
-                  "label": "Static Id Document Controller",
+                  "label": "Agents Controller",
                   "preResponseHandler": {
                     "@type": "HttpSequenceContextHandler",
                     "contextHandlers": [
@@ -48,29 +48,12 @@
                           "@id": "urn:ssv:SessionManager"
                         }
                       }
-                    },
-                    {
-                      "@type": "HttpHandlerRoute",
-                      "path": "/agents/:uuid/redirect",
-                      "operations": [
-                        {
-                          "@type": "HttpHandlerOperation",
-                          "method": "GET",
-                          "publish": false
-                        }
-                      ],
-                      "handler": {
-                        "@type": "LoginRedirectHandler",
-                        "sessionManager": {
-                          "@id": "urn:ssv:SessionManager"
-                        }
-                      }
                     }
                   ]
                 },
                 {
                   "@type": "HttpHandlerController",
-                  "label": "Default Controller",
+                  "label": "Login Controller",
                   "preResponseHandler": {
                     "@type": "HttpSequenceContextHandler",
                     "contextHandlers": [
@@ -98,7 +81,30 @@
                       }
                     }
                   ]
-                }
+                },
+                {
+                  "@type": "HttpHandlerController",
+                  "label": "Login Redirect Controler",
+                  "routes": [
+                    {
+                      "@type": "HttpHandlerRoute",
+                      "path": "/agents/:uuid/redirect",
+                      "operations": [
+                        {
+                          "@type": "HttpHandlerOperation",
+                          "method": "GET",
+                          "publish": false
+                        }
+                      ],
+                      "handler": {
+                        "@type": "LoginRedirectHandler",
+                        "sessionManager": {
+                          "@id": "urn:ssv:SessionManager"
+                        }
+                      }
+                    }
+                  ]
+                },
               ]
             }
           }

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -25,7 +25,7 @@
     "build:watch": "tsc --watch",
     "clean": "rm -rf dist/",
     "test:unit": "jest test/unit",
-    "test:integration": "npm run build && jest test/integration --coverage=false",
+    "test:integration": "npm run build && jest --coverage=false --runInBand test/integration",
     "test": "npm run test:unit && npm run test:integration",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/packages/service/src/handlers/agents-handler.ts
+++ b/packages/service/src/handlers/agents-handler.ts
@@ -1,7 +1,7 @@
 import { from, Observable } from "rxjs";
 import { HttpHandler, HttpHandlerResponse, UnauthorizedHttpError } from "@digita-ai/handlersjs-http";
 import { INTEROP } from "@janeirodigital/interop-namespaces";
-import { HttpSolidContext } from "../models/http-solid-context";
+import { AuthnContext } from "../models/http-solid-context";
 import { uuid2agentUrl, agentRedirectUrl } from "../url-templates";
 import { ISessionManager } from "@janeirodigital/sai-server-interfaces";
 
@@ -23,9 +23,9 @@ export class AgentsHandler extends HttpHandler {
     }
   }
 
-  async handleAsync(context: HttpSolidContext): Promise<HttpHandlerResponse> {
+  async handleAsync(context: AuthnContext): Promise<HttpHandlerResponse> {
     const agentUrl = uuid2agentUrl(context.request.parameters!.uuid)
-    if (!context.authn) {
+    if (!context.authn.authenticated) {
       return {
         body: this.clientIdDocument(agentUrl),
         status: 200,
@@ -61,7 +61,7 @@ export class AgentsHandler extends HttpHandler {
     }
   }
 
-  handle(context: HttpSolidContext): Observable<HttpHandlerResponse> {
+  handle(context: AuthnContext): Observable<HttpHandlerResponse> {
     return from(this.handleAsync(context))
   }
 }

--- a/packages/service/src/handlers/authorization-agent-context-handler.ts
+++ b/packages/service/src/handlers/authorization-agent-context-handler.ts
@@ -1,5 +1,5 @@
 import { HttpContextHandler } from "./middleware-http-handler";
-import { AuthnContext, SaiContext } from "../models/http-solid-context";
+import { AuthenticatedAuthnContext, SaiContext } from "../models/http-solid-context";
 import { SessionManager } from "../session-manager";
 import { from, Observable } from "rxjs";
 import { InternalServerError, UnauthorizedHttpError } from "@digita-ai/handlersjs-http";
@@ -10,16 +10,11 @@ import { InternalServerError, UnauthorizedHttpError } from "@digita-ai/handlersj
 export class AuthorizationAgentContextHandler implements HttpContextHandler {
   constructor(private manager: SessionManager) {}
 
-  handle(ctx: AuthnContext): Observable<SaiContext> {
+  handle(ctx: AuthenticatedAuthnContext): Observable<SaiContext> {
     return from(this.handleAsync(ctx));
   }
 
-
-  private async handleAsync(ctx: AuthnContext): Promise<SaiContext> {
-    if (!ctx.authn.webId) {
-      throw new UnauthorizedHttpError();
-    }
-
+  private async handleAsync(ctx: AuthenticatedAuthnContext): Promise<SaiContext> {
     const saiSession = await this.manager.getSaiSession(ctx.authn.webId);
 
     if (!saiSession) {

--- a/packages/service/src/handlers/login-handler.ts
+++ b/packages/service/src/handlers/login-handler.ts
@@ -6,7 +6,7 @@ import { getLoggerFor } from '@digita-ai/handlersjs-logging';
 import { Session } from "@inrupt/solid-client-authn-node";
 import { ISessionManager } from "@janeirodigital/sai-server-interfaces";
 import { agentRedirectUrl, uuid2agentUrl } from "../url-templates";
-import { AuthnContext } from "../models/http-solid-context";
+import { AuthenticatedAuthnContext } from "../models/http-solid-context";
 import { validateContentType } from "../utils/http-validators";
 
 export class LoginHandler extends HttpHandler {
@@ -19,7 +19,7 @@ export class LoginHandler extends HttpHandler {
     this.logger.info("LoginHandler::constructor");
   }
 
-  async handleAsync (context: AuthnContext): Promise<HttpHandlerResponse> {
+  async handleAsync (context: AuthenticatedAuthnContext): Promise<HttpHandlerResponse> {
 
     validateContentType(context, 'application/json');
 
@@ -52,7 +52,7 @@ export class LoginHandler extends HttpHandler {
         oidcIssuer: idp,
         clientName: process.env.APP_NAME,
         clientId: agentUrl,
-        handleRedirect: (url) => {
+        handleRedirect: (url: string) => {
           resolve(url)
         }
       })
@@ -61,7 +61,7 @@ export class LoginHandler extends HttpHandler {
     return { body: { redirectUrl: completeRedirectUrl }, status: 200, headers: {} }
   }
 
-  handle(context: AuthnContext): Observable<HttpHandlerResponse> {
+  handle(context: AuthenticatedAuthnContext): Observable<HttpHandlerResponse> {
     this.logger.info("LoginHandler::handle");
     return from(this.handleAsync(context))
   }

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -9,7 +9,6 @@ export * from "./handlers/agents-handler";
 export * from "./handlers/middleware-http-handler";
 export * from "./handlers/authn-context-handler";
 export * from "./handlers/authorization-agent-context-handler";
-export * from "./handlers/oidc-session-context-handler";
 // Models
 export * from "./models/http-solid-context";
 export * from "./session-manager";

--- a/packages/service/src/models/http-solid-context.ts
+++ b/packages/service/src/models/http-solid-context.ts
@@ -6,11 +6,20 @@ export interface SaiContext extends HttpHandlerContext {
   saiSession: AuthorizationAgent;
 }
 
-export interface AuthnContext extends HttpHandlerContext {
+
+export interface UnauthenticatedAuthnContext extends HttpHandlerContext {
   authn: {
+    authenticated: false;
+  }
+}
+export interface AuthenticatedAuthnContext extends HttpHandlerContext {
+  authn: {
+    authenticated: true;
     webId: string;
-    clientId?: string;
+    clientId: string;
   }
 }
 
-export type  HttpSolidContext = SaiContext & AuthnContext;
+export type AuthnContext = UnauthenticatedAuthnContext | AuthenticatedAuthnContext
+
+export type HttpSolidContext =  SaiContext & AuthnContext;

--- a/packages/service/test/integration/agents-test.ts
+++ b/packages/service/test/integration/agents-test.ts
@@ -1,0 +1,176 @@
+import { jest } from '@jest/globals';
+import { lastValueFrom } from 'rxjs'
+import { ComponentsManager } from 'componentsjs';
+import { Server } from '@digita-ai/handlersjs-http';
+import { createSolidTokenVerifier, SolidAccessTokenPayload, SolidTokenVerifierFunction } from '@solid/access-token-verifier';
+import { MockedSessionManager } from '@janeirodigital/sai-server-mocks'
+import { AuthorizationAgent } from '@janeirodigital/interop-authorization-agent';
+import { INTEROP } from '@janeirodigital/interop-namespaces';
+import { baseUrl, agentRedirectUrl, uuid2agentUrl } from '../../src/url-templates'
+import { createTestServer } from "./components-builder";
+
+jest.mock('@solid/access-token-verifier', () => {
+  return {
+    createSolidTokenVerifier: jest.fn()
+  }
+})
+const mockedCreateSolidTokenVerifier = jest.mocked(createSolidTokenVerifier)
+
+let server: Server
+let componentsManager: ComponentsManager<Server>
+let manager: MockedSessionManager
+
+const webId = 'https://alice.example'
+const agentUuid = '75340942-4225-42e0-b897-5f36278166de';
+const dpopProof = 'dpop-proof'
+const authorization = 'DPoP some-token'
+const clientId = 'https://projectron.example'
+const agentUrl = uuid2agentUrl(agentUuid)
+
+beforeAll(async () => {
+  const created = await createTestServer()
+  server = created.server
+  componentsManager = created.componentsManager
+  await lastValueFrom(server.start())
+  const instanceRegistry = await componentsManager.configConstructorPool.getInstanceRegistry()
+  manager = await instanceRegistry["urn:ssv:SessionManager"] as unknown as MockedSessionManager
+})
+
+afterAll(async () => {
+  await lastValueFrom(server.stop())
+})
+
+beforeEach(async () => {
+  mockedCreateSolidTokenVerifier.mockReset()
+})
+
+describe("unauthenticated request", () => {
+  const path = `/agents/${agentUuid}`
+  const url = `${baseUrl}${path}`
+
+  test('should contain valid Client ID Document', async() => {
+    const response = await fetch(url, {
+      method: 'GET'
+    })
+    expect(response.ok).toBe(true)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/ld+json')
+
+    const document = await response.json()
+    expect(document.client_id).toContain(agentUuid);
+    expect(document.redirect_uris).toContain(agentRedirectUrl(agentUuid));
+    expect(document.grant_types).toEqual(expect.arrayContaining(['authorization_code', 'refresh_token']));
+  })
+})
+
+// This is handled by AuthnContextHandler
+describe("request without client_id", () => {
+  const path = `/agents/${agentUuid}`
+  const url = `${baseUrl}${path}`
+
+  test('should respond 401 when applicationId from token is undefined', async () => {
+    mockedCreateSolidTokenVerifier.mockImplementation(() => {
+      return async function verifier (authorizationHeader, dpop) {
+        expect(authorizationHeader).toBe(authorization)
+        expect(dpop).toEqual({
+          header: dpopProof,
+          method: 'GET',
+          url
+        })
+        return { webid: webId } as SolidAccessTokenPayload
+      } as SolidTokenVerifierFunction
+    })
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'DPoP': dpopProof,
+        'Authorization': authorization
+      }
+    })
+
+    expect(response.ok).toBeFalsy()
+    expect(response.status).toBe(401)
+  });
+})
+
+describe('authenticated request', () => {
+  const path = `/agents/${agentUuid}`
+  const url = `${baseUrl}${path}`
+  const headers = {
+    'DPoP': dpopProof,
+    'Authorization': authorization
+  }
+
+  test('application registration discovery', async () => {
+    const applicationRegistrationIri = 'https://some.example/application-registration'
+
+    mockedCreateSolidTokenVerifier.mockImplementation(() => {
+      return async function verifier (authorizationHeader, dpop) {
+        expect(authorizationHeader).toBe(authorization)
+        expect(dpop).toEqual({
+          header: dpopProof,
+          method: 'GET',
+          url
+        })
+        return { webid: webId, client_id: clientId } as SolidAccessTokenPayload
+      } as SolidTokenVerifierFunction
+    })
+
+    manager.getFromAgentUrl.mockImplementationOnce(async (url) => {
+      return {
+        webId,
+        findApplicationRegistration: async (applicationId) => {
+          expect(applicationId).toBe(clientId)
+          return { iri: applicationRegistrationIri}
+        }
+      } as AuthorizationAgent
+    })
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+    })
+    expect(manager.getFromAgentUrl).toBeCalledWith(agentUrl)
+    expect(response.ok).toBe(true)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Link')).toBe(`<${clientId}>; anchor="${applicationRegistrationIri}"; rel="${INTEROP.registeredAgent.value}"`)
+  });
+
+  test('social agent registration discovery', async () => {
+    const differentWebId = 'https://different-user.example/'
+    const socialAgentRegistrationIri = 'https://some.example/application-registration'
+
+    mockedCreateSolidTokenVerifier.mockImplementation(() => {
+      return async function verifier (authorizationHeader, dpop) {
+        expect(authorizationHeader).toBe(authorization)
+        expect(dpop).toEqual({
+          header: dpopProof,
+          method: 'GET',
+          url
+        })
+        return { webid: differentWebId, client_id: clientId } as SolidAccessTokenPayload
+      } as SolidTokenVerifierFunction
+    })
+
+    manager.getFromAgentUrl.mockImplementation(async (url) => {
+      expect(url).toBe(agentUrl)
+      return {
+        webId,
+        findSocialAgentRegistration: async (webid) => {
+          expect(webid).toBe(differentWebId)
+          return { iri: socialAgentRegistrationIri}
+        }
+      } as AuthorizationAgent
+    })
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+    })
+
+    expect(manager.getFromAgentUrl).toBeCalledWith(agentUrl)
+    expect(response.ok).toBe(true)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Link')).toBe(`<${clientId}>; anchor="${socialAgentRegistrationIri}"; rel="${INTEROP.registeredAgent.value}"`)
+  })
+})

--- a/packages/service/test/unit/handlers/authorization-agent-context-handler-test.ts
+++ b/packages/service/test/unit/handlers/authorization-agent-context-handler-test.ts
@@ -1,4 +1,4 @@
-import { AuthnContext, AuthorizationAgentContextHandler, SessionManager } from "../../../src";
+import { AuthenticatedAuthnContext, AuthorizationAgentContextHandler, SessionManager } from "../../../src";
 import { InMemoryStorage } from "@inrupt/solid-client-authn-node";
 import { InternalServerError, UnauthorizedHttpError } from "@digita-ai/handlersjs-http";
 
@@ -13,21 +13,11 @@ describe("AuthorizationAgentContextHandler", () => {
     authorizationAgentContextHandler = new AuthorizationAgentContextHandler(manager);
   });
 
-  test("throws with UnauthorizedRequest if the ctx does not provide a webid", (done) => {
-    const ctx = { authn: { webId: undefined } } as unknown as AuthnContext;
-    authorizationAgentContextHandler.handle(ctx).subscribe({
-      error(e: Error) {
-        expect(e).toBeInstanceOf(UnauthorizedHttpError);
-        done();
-      }
-    });
-  });
-
   test("retrieves the right session from manager", (done) => {
     manager.getSaiSession = jest.fn().mockReturnValueOnce(Promise.resolve(Object()));
 
     const webId = "http://me.id";
-    const ctx = { authn: { webId } } as AuthnContext;
+    const ctx = { authn: { webId, authenticated: true } } as AuthenticatedAuthnContext;
     authorizationAgentContextHandler.handle(ctx).subscribe(() => {
       expect(manager.getSaiSession).toBeCalledWith(webId);
       done();
@@ -38,7 +28,7 @@ describe("AuthorizationAgentContextHandler", () => {
     manager.getSaiSession = jest.fn().mockReturnValueOnce(Promise.resolve(Object()));
     const webId = "http://me.id";
 
-    const ctx = { authn: { webId } } as AuthnContext;
+    const ctx = { authn: { webId, authenticated: true } } as AuthenticatedAuthnContext;
     authorizationAgentContextHandler.handle(ctx).subscribe((nextCtx) => {
       expect(nextCtx.saiSession).toEqual(Object());
       done();
@@ -49,7 +39,7 @@ describe("AuthorizationAgentContextHandler", () => {
     manager.getSaiSession = jest.fn().mockReturnValueOnce(Promise.resolve(undefined));
     const webId = "http://me.id";
 
-    const ctx = { authn: { webId } } as AuthnContext;
+    const ctx = { authn: { webId, authenticated: true } } as AuthenticatedAuthnContext;
 
     authorizationAgentContextHandler.handle(ctx).subscribe({
       error(e: Error) {

--- a/packages/service/test/unit/handlers/login-handler-test.ts
+++ b/packages/service/test/unit/handlers/login-handler-test.ts
@@ -2,7 +2,7 @@ import { jest } from "@jest/globals";
 import { Mock } from "jest-mock";
 import { InMemoryStorage, Session } from "@inrupt/solid-client-authn-node";
 import { HttpError, BadRequestHttpError, HttpHandlerRequest } from "@digita-ai/handlersjs-http";
-import { agentRedirectUrl, agentUuid, AuthnContext, LoginHandler } from "../../../src";
+import { agentRedirectUrl, agentUuid, AuthenticatedAuthnContext, AuthnContext, LoginHandler } from "../../../src";
 
 import { SessionManager } from "../../../src/session-manager";
 
@@ -52,7 +52,7 @@ describe('authenticated request', () => {
     const request = {
       headers: {},
     } as unknown as HttpHandlerRequest
-    const ctx = { request, authn } as AuthnContext;
+    const ctx = { request, authn } as AuthenticatedAuthnContext;
 
     loginHandler.handle(ctx).subscribe({
       error: (e: HttpError) => {
@@ -68,7 +68,7 @@ describe('authenticated request', () => {
         'content-type': 'application/json'
       },
     } as unknown as HttpHandlerRequest
-    const ctx = { request, authn } as AuthnContext;
+    const ctx = { request, authn } as AuthenticatedAuthnContext;
 
     loginHandler.handle(ctx).subscribe({
       error: (e: HttpError) => {
@@ -85,7 +85,7 @@ describe('authenticated request', () => {
       },
       body: { idp }
     } as unknown as HttpHandlerRequest
-    const ctx = { request, authn } as AuthnContext;
+    const ctx = { request, authn } as AuthenticatedAuthnContext;
     manager.getOidcSession.mockImplementationOnce(async (webId) => {
       expect(webId).toBe(aliceWebId)
       return {
@@ -113,7 +113,7 @@ describe('authenticated request', () => {
       },
       body: { idp }
     } as unknown as HttpHandlerRequest
-    const ctx = { request, authn } as AuthnContext;
+    const ctx = { request, authn } as AuthenticatedAuthnContext;
     manager.getOidcSession.mockImplementationOnce(async (webId) => {
       expect(webId).toBe(aliceWebId)
       return {
@@ -146,7 +146,7 @@ describe('authenticated request', () => {
       },
       body: { idp }
     } as unknown as HttpHandlerRequest
-    const ctx = { request, authn } as AuthnContext;
+    const ctx = { request, authn } as AuthenticatedAuthnContext;
     MockedSession.mockImplementationOnce((sessionOptions: any, sessionId: string) => {
       expect(sessionId).toBe(aliceWebId)
       return {


### PR DESCRIPTION
@angelaraya can you especially check changes to AuthnContext.
Old behavior stayed as default, now we can also instantiate it with `strict=false` to allow unauthenticated requests to agents handler. I'll point it out inline.