### PR TITLE
include descriptions from shape trees

### DIFF
--- a/packages/css-storage-fixture/.internal/accounts/YWNjb3VudC9hZG1pbiU0MHNoYXBldHJlZXMuZXhhbXBsZQ==$.json
+++ b/packages/css-storage-fixture/.internal/accounts/YWNjb3VudC9hZG1pbiU0MHNoYXBldHJlZXMuZXhhbXBsZQ==$.json
@@ -1,0 +1,1 @@
+{"email":"admin@shapetrees.example","password":"$2a$10$hNiLt3JyAr0hC9sIq43/w.hd2j.jbwmED8MskiRDQQc4mOWqNitf6","verified":true,"webId":"http://localhost:3000/shapetrees/profile/card#me"}

--- a/packages/css-storage-fixture/.internal/accounts/aHR0cDovL2xvY2FsaG9zdDozMDAwL3NoYXBldHJlZXMvcHJvZmlsZS9jYXJkI21l$.json
+++ b/packages/css-storage-fixture/.internal/accounts/aHR0cDovL2xvY2FsaG9zdDozMDAwL3NoYXBldHJlZXMvcHJvZmlsZS9jYXJkI21l$.json
@@ -1,0 +1,1 @@
+{"useIdp":true,"podBaseUrl":"http://localhost:3000/shapetrees/","clientCredentials":[]}

--- a/packages/css-storage-fixture/README.md
+++ b/packages/css-storage-fixture/README.md
@@ -6,6 +6,8 @@ All accounts use `password` as the password
 
 * alice@acme.example
 * bob@yoyodyne.example
+* acme@acme.example
+* admin@shapetrees.example
 
 ## Starting CSS
 

--- a/packages/css-storage-fixture/acme/projectron/access-needs$.ttl
+++ b/packages/css-storage-fixture/acme/projectron/access-needs$.ttl
@@ -1,6 +1,7 @@
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX interop: <http://www.w3.org/ns/solid/interop#>
 PREFIX acl: <http://www.w3.org/ns/auth/acl#>
-PREFIX pm-shapetrees: <https://data.example/shapetrees/pm-shapetrees#>
+PREFIX solidtrees: <http://localhost:3000/shapetrees/trees/>
 
 <./access-needs>
   a interop:AccessNeedGroup ;
@@ -13,15 +14,18 @@ PREFIX pm-shapetrees: <https://data.example/shapetrees/pm-shapetrees#>
 
 <#need-project>
   a interop:AccessNeed ;
-  interop:registeredShapeTree pm-shapetrees:ProjectTree ;
+  interop:registeredShapeTree solidtrees:Project ;
   interop:accessNecessity interop:accessRequired ;
   interop:accessMode acl:Read, acl:Create ;
   interop:creatorAccessMode acl:Update, acl:Delete .
 
 <#need-task>
   a interop:AccessNeed ;
-  interop:registeredShapeTree pm-shapetrees:TaskTree ;
+  interop:registeredShapeTree solidtrees:Task ;
   interop:accessNecessity interop:accessRequired ;
   interop:accessMode acl:Read, acl:Create ;
   interop:creatorAccessMode acl:Update, acl:Delete ;
   interop:inheritsFromNeed <#need-project> .
+
+<./descriptions-en>
+  interop:usesLanguage "en"^^xsd:language .

--- a/packages/css-storage-fixture/acme/projectron/descriptions-en$.ttl
+++ b/packages/css-storage-fixture/acme/projectron/descriptions-en$.ttl
@@ -12,7 +12,7 @@ PREFIX interop: <http://www.w3.org/ns/solid/interop#>
   interop:inAccessDescriptionSet <> ;
   interop:hasAccessNeedGroup <./access-needs#need-group-pm> ;
   skos:prefLabel "Read and Contribute to Projects"@en ;
-  skos:description "Allow Projectron to read the Projects you select, and create new ones. Projectron won't modify existing data, but can add more."@en .
+  skos:definition "Allow Projectron to read the Projects you select, and create new ones. Projectron won't modify existing data, but can add more."@en .
 
 <#en-need-project>
   a interop:AccessNeedDescription ;
@@ -23,5 +23,5 @@ PREFIX interop: <http://www.w3.org/ns/solid/interop#>
 <#en-need-task>
   a interop:AccessNeedDescription ;
   interop:inAccessDescriptionSet <> ;
-  interop:hasAccessNeed <./access-needs/need-task> ;
+  interop:hasAccessNeed <./access-needs#need-task> ;
   skos:prefLabel "Access to Tasks allows Projectron to identify and manage the work to be done in a given Project."@en .

--- a/packages/css-storage-fixture/shapetrees/.acl
+++ b/packages/css-storage-fixture/shapetrees/.acl
@@ -1,0 +1,27 @@
+# Root ACL resource for the agent account
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# The homepage is readable by the public
+<#public>
+    a acl:Authorization;
+    acl:agentClass foaf:Agent;
+    acl:accessTo <./>;
+    acl:default <./>;
+    acl:mode acl:Read.
+
+# The owner has full access to every resource in their pod.
+# Other agents have no access rights,
+# unless specifically authorized in other .acl resources.
+<#owner>
+    a acl:Authorization;
+    acl:agent <http://localhost:3000/shapetrees/profile/card#me>;
+    # Optional owner email, to be used for account recovery:
+    acl:agent <mailto:admin@shapetrees.example>;
+    # Set the access to the root storage folder itself
+    acl:accessTo <./>;
+    # All resources will inherit this authorization, by default
+    acl:default <./>;
+    # The owner has all of the access modes allowed
+    acl:mode
+        acl:Read, acl:Write, acl:Control.

--- a/packages/css-storage-fixture/shapetrees/.meta
+++ b/packages/css-storage-fixture/shapetrees/.meta
@@ -1,0 +1,1 @@
+<http://localhost:3000/shapetrees/> a <http://www.w3.org/ns/pim/space#Storage>.

--- a/packages/css-storage-fixture/shapetrees/README$.markdown
+++ b/packages/css-storage-fixture/shapetrees/README$.markdown
@@ -1,0 +1,22 @@
+# Welcome to your pod
+
+## A place to store your data
+Your pod is a **secure storage space** for your documents and data.
+<br>
+You can choose to share those with other people and apps.
+
+As the owner of this pod,
+identified by <a href="http://localhost:3000/shapetrees/profile/card#me">http://localhost:3000/shapetrees/profile/card#me</a>,
+you have access to all of your documents.
+
+## Working with your pod
+The easiest way to interact with pods
+is through Solid apps.
+<br>
+For example,
+you can open your pod in [Databrowser](https://solidos.github.io/mashlib/dist/browse.html?uri=http://localhost:3000/shapetrees/).
+
+## Learn more
+The [Solid website](https://solidproject.org/)
+and the people on its [forum](https://forum.solidproject.org/)
+will be glad to help you on your journey.

--- a/packages/css-storage-fixture/shapetrees/README.acl
+++ b/packages/css-storage-fixture/shapetrees/README.acl
@@ -1,0 +1,14 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<#public>
+    a acl:Authorization;
+    acl:accessTo <./README>;
+    acl:agentClass foaf:Agent;
+    acl:mode acl:Read.
+
+<#owner>
+    a acl:Authorization;
+    acl:accessTo <./README>;
+    acl:agent <http://localhost:3000/shapetrees/profile/card#me>;
+    acl:mode acl:Read, acl:Write, acl:Control.

--- a/packages/css-storage-fixture/shapetrees/profile/card$.ttl
+++ b/packages/css-storage-fixture/shapetrees/profile/card$.ttl
@@ -1,0 +1,12 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+
+<>
+    a foaf:PersonalProfileDocument;
+    foaf:maker <http://localhost:3000/shapetrees/profile/card#me>;
+    foaf:primaryTopic <http://localhost:3000/shapetrees/profile/card#me>.
+
+<http://localhost:3000/shapetrees/profile/card#me>
+    
+    solid:oidcIssuer <http://localhost:3000/>;
+    a foaf:Person.

--- a/packages/css-storage-fixture/shapetrees/profile/card.acl
+++ b/packages/css-storage-fixture/shapetrees/profile/card.acl
@@ -1,0 +1,19 @@
+# ACL resource for the WebID profile document
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# The WebID profile is readable by the public.
+# This is required for discovery and verification,
+# e.g. when checking identity providers.
+<#public>
+    a acl:Authorization;
+    acl:agentClass foaf:Agent;
+    acl:accessTo <./card>;
+    acl:mode acl:Read.
+
+# The owner has full access to the profile
+<#owner>
+    a acl:Authorization;
+    acl:agent <http://localhost:3000/shapetrees/profile/card#me>;
+    acl:accessTo <./card>;
+    acl:mode acl:Read, acl:Write, acl:Control.

--- a/packages/css-storage-fixture/shapetrees/trees/Project$.ttl
+++ b/packages/css-storage-fixture/shapetrees/trees/Project$.ttl
@@ -1,0 +1,23 @@
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX uuid: <urn:uuid>
+PREFIX shapetrees: <http://www.w3.org/ns/shapetrees#>
+PREFIX solidshapes: <http://localhost:3000/shapetrees/shapes/>
+PREFIX solidtrees: <http://localhost:3000/shapetrees/trees/>
+
+solidtrees:Project
+  a shapetrees:ShapeTree ;
+  shapetrees:expectsType shapetrees:Resource ;
+  shapetrees:shape solidshapes:Project ;
+  shapetrees:references uuid:54b5e4f6-c6b5-4c9a-b885-cbf69d08370d .
+
+uuid:54b5e4f6-c6b5-4c9a-b885-cbf69d08370d
+  shapetrees:hasShapeTree solidtrees:Task ;
+  shapetrees:viaShapePath
+    "@<https://solidshapes.example/shapes/Project>~<https://vocab.example/project-management/hasTask>" .
+
+solidtrees:desc-en\#Project
+  shapetrees:inDescriptionSet solidtrees:desc-en ;
+  shapetrees:describes solidtrees:Project .
+
+solidtrees:desc-en
+  shapetrees:usesLanguage "en"^^xsd:language .

--- a/packages/css-storage-fixture/shapetrees/trees/Task$.ttl
+++ b/packages/css-storage-fixture/shapetrees/trees/Task$.ttl
@@ -1,0 +1,16 @@
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX shapetrees: <http://www.w3.org/ns/shapetrees#>
+PREFIX solidshapes: <http://localhost:3000/shapetrees/shapes/>
+PREFIX solidtrees: <http://localhost:3000/shapetrees/trees/>
+
+solidtrees:Task
+  a shapetrees:ShapeTree ;
+  shapetrees:expectsType shapetrees:Resource ;
+  shapetrees:shape solidshapes:Task .
+
+solidtrees:desc-en\#Task
+  shapetrees:inDescriptionSet solidtrees:desc-en ;
+  shapetrees:describes solidtrees:Task .
+
+solidtrees:desc-en
+  shapetrees:usesLanguage "en"^^xsd:language .

--- a/packages/css-storage-fixture/shapetrees/trees/desc-en$.ttl
+++ b/packages/css-storage-fixture/shapetrees/trees/desc-en$.ttl
@@ -1,0 +1,21 @@
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX shapetrees: <http://www.w3.org/ns/shapetrees#>
+PREFIX solidshapes: <http://localhost:3000/shapetrees/shapes/>
+PREFIX solidtrees: <http://localhost:3000/shapetrees/trees/>
+
+solidtrees:desc-en
+  a shapetrees:DescriptionSet ;
+  shapetrees:usesLanguage "en"^^xsd:language .
+
+solidtrees:desc-en\#Project
+  a shapetrees:Description ;
+  shapetrees:inDescriptionSet solidtrees:desc-en ;
+  shapetrees:describes solidshapes:Project ;
+  skos:prefLabel "Projects"@en .
+
+solidtrees:desc-en\#Task
+  a shapetrees:Description ;
+  shapetrees:inDescriptionSet solidtrees:desc-en ;
+  shapetrees:describes solidshapes:Task ;
+  skos:prefLabel "Tasks"@en .

--- a/packages/service/src/services/descriptions.ts
+++ b/packages/service/src/services/descriptions.ts
@@ -1,65 +1,214 @@
-import { INTEROP, buildNamespace } from "@janeirodigital/interop-namespaces";
+import { XSD, INTEROP, SHAPETREES, buildNamespace } from "@janeirodigital/interop-namespaces";
 import { parseTurtle } from "@janeirodigital/interop-utils"
-import { getOneObject } from "../utils/rdf-parser";
+import { IRI } from "@janeirodigital/sai-api-messages"
+import { getOneObject, getOneSubject, getAllSubjects, getAllObjects } from "../utils/rdf-parser";
 import { parseJsonld } from "../utils/jsonld-parser";
+import { DatasetCore, NamedNode } from "@rdfjs/types";
+import { Store, DataFactory } from "n3";
 
 // TODO (elf-pavlik) add to interop-namespaces
 const SKOS = buildNamespace('http://www.w3.org/2004/02/skos/core#')
 
+class Resource {
+
+  public node: NamedNode
+  public dataset: DatasetCore = new Store()
+
+  constructor(public iri: IRI) {
+    this.node = DataFactory.namedNode(iri)
+  }
+
+  protected async fetchData(): Promise<void> {
+    const response = await fetch(this.iri)
+    this.dataset = await parseTurtle(await response.text(), response.url)
+  }
+
+  protected async bootstrap(): Promise<void> {
+    await this.fetchData()
+  }
+}
+
+class AccessDescription extends Resource {
+  constructor(public iri: IRI, public dataset: DatasetCore) {
+    super(iri)
+  }
+
+  public get label (): string | undefined {
+    return getOneObject(this.dataset.match(this.node, SKOS.prefLabel))?.value;
+  }
+
+  public get definition (): string | undefined {
+    return getOneObject(this.dataset.match(this.node, SKOS.definition))?.value;
+  }
+}
+
+class AccessNeedDescription extends AccessDescription {
+  public get accessNeed(): string {
+    return getOneObject(this.dataset.match(this.node, INTEROP.hasAccessNeed))!.value;
+  }
+}
+
+class AccessNeedGroupDescription extends AccessDescription {
+  public get accessNeedGroup(): string | undefined {
+    return getOneObject(this.dataset.match(this.node, INTEROP.hasAccessNeedGroup))?.value;
+  }
+}
+
+class AccessDescriptionSet extends Resource {
+
+  private get descriptionSubjects() {
+    return getAllSubjects(this.dataset.match(null, INTEROP.inAccessDescriptionSet));
+  }
+
+  get accessNeedGroupDescriptions(): AccessNeedGroupDescription[] {
+    return this.descriptionSubjects
+      .filter(subject => this.dataset.match(subject, INTEROP.hasAccessNeedGroup).size)
+      .map(subject => new AccessNeedGroupDescription(subject.value, this.dataset))
+  }
+
+  get accessNeedDescriptions(): AccessNeedDescription[] {
+    return this.descriptionSubjects
+      .filter(subject => this.dataset.match(subject, INTEROP.hasAccessNeed).size)
+      .map(subject => new AccessNeedDescription(subject.value, this.dataset))
+  }
+
+  public static async build (iri: IRI): Promise<AccessDescriptionSet> {
+    const instance = new AccessDescriptionSet(iri)
+    await instance.bootstrap()
+    return instance
+  }
+
+}
+
+class ShapeTree extends Resource {
+  public static async build (iri: IRI): Promise<ShapeTree> {
+    const instance = new ShapeTree(iri)
+    await instance.bootstrap()
+    return instance
+  }
+}
+
+class ShapeTreeDescription extends Resource {
+
+  public get label (): string | undefined {
+    return getOneObject(this.dataset.match(this.node, SKOS.prefLabel))?.value;
+  }
+
+  public get definition (): string | undefined {
+    return getOneObject(this.dataset.match(this.node, SKOS.definition))?.value;
+  }
+
+  public static async build (iri: IRI): Promise<ShapeTreeDescription> {
+    const instance = new ShapeTreeDescription(iri)
+    await instance.bootstrap()
+    return instance
+  }
+}
+
+type DescriptionsIndex = { [key: IRI]: ShapeTreeDescription }
+
+class AccessNeedGroup extends Resource {
+
+  accessDescriptionSet?: AccessDescriptionSet
+  shapeTreeDescriptions: DescriptionsIndex = {}
+
+  constructor(iri: IRI, public descriptionsLang: string) {
+    super(iri)
+  }
+
+  public async getAccessDescriptionSet(): Promise<AccessDescriptionSet | undefined> {
+
+    // we can skip matching on INTEROP.hasAccessDescriptionSet since nothing else uses INTEROP.usesLanguage
+    const descriptionSetIri = getOneSubject(this.dataset.match(null, INTEROP.usesLanguage, DataFactory.literal(this.descriptionsLang, XSD.language)))?.value
+    if (!descriptionSetIri) return
+    return AccessDescriptionSet.build(descriptionSetIri)
+  }
+
+  public async getShapeTreeDescriptions(): Promise<DescriptionsIndex> {
+    const index: DescriptionsIndex = {}
+    const shapeTreeIris = [... new Set(getAllObjects(this.dataset.match(null, INTEROP.registeredShapeTree)).map(node => node.value))]
+    const shapeTrees = await Promise.all(shapeTreeIris.map(ShapeTree.build))
+    for (const shapeTree of shapeTrees) {
+      const descriptionSetNode = getOneSubject(shapeTree.dataset.match(null, SHAPETREES.usesLanguage, DataFactory.literal(this.descriptionsLang, XSD.language)))
+      if (!descriptionSetNode) continue
+      const descriptionNodes = getAllSubjects(shapeTree.dataset.match(null, SHAPETREES.describes, shapeTree.node))
+      const descriptionIri = descriptionNodes.filter(node => {
+        return shapeTree.dataset.match(node, SHAPETREES.inDescriptionSet, descriptionSetNode)
+      }).shift()?.value
+      if (descriptionIri) {
+        index[shapeTree.iri] = await ShapeTreeDescription.build(descriptionIri)
+      }
+    }
+    return index
+  }
+
+  public getShapeTreeDescriptionForNeed(needIri: IRI): IShapeTreeDescription | undefined {
+    const shapeTreeIri = getOneObject(this.dataset.match(DataFactory.namedNode(needIri), INTEROP.registeredShapeTree, null))?.value
+    if (!shapeTreeIri) return
+    const description = this.shapeTreeDescriptions[shapeTreeIri]
+    if (!description) return
+    return {
+      label: description.label,
+      definition: description.definition
+    }
+  }
+
+  protected async bootstrap(): Promise<void> {
+    await super.bootstrap()
+    this.accessDescriptionSet = await this.getAccessDescriptionSet()
+    this.shapeTreeDescriptions = await this.getShapeTreeDescriptions()
+  }
+
+  public static async build (iri: IRI, descriptionsLang: string): Promise<AccessNeedGroup> {
+    const instance = new AccessNeedGroup(iri, descriptionsLang)
+    await instance.bootstrap()
+    return instance
+  }
+}
+
+interface IShapeTreeDescription {
+  label?: string,
+  definition?: string
+}
+
+async function discoverAccessNeeedGroup(applicationIri: IRI): Promise<IRI | undefined> {
+  const clientIdResponse = await fetch(applicationIri)
+  const document = await parseJsonld(await clientIdResponse.text(), clientIdResponse.url)
+  return getOneObject(
+    document.match(null, INTEROP.hasAccessNeedGroup)
+  )?.value
+}
+
 /**
  * Get the descriptions for the requested language. If the descriptions for the language are not found
  * `null` will be returned.
- * TODO (angel) handle cases where the target description set is not in the same graph and needs to be fetched
- *              from another resource.
- * @param agent Authorization Agent instance
  * @param applicationIri application's profile document IRI
- * @param targetLang XSD language requested, e.g.: "en", "es", "i-navajo".
+ * @param descriptionsLang XSD language requested, e.g.: "en", "es", "i-navajo".
  */
 export const getDescriptions = async (
   applicationIri: string,
-  targetLang: string
+  descriptionsLang: string
 ) => {
-  const clientIdResponse = await fetch(applicationIri)
-  const document = await parseJsonld(await clientIdResponse.text(), clientIdResponse.url)
-  const accessNeedGroupIri = getOneObject(
-    document.match(null, INTEROP.hasAccessNeedGroup)
-  )?.value
+
+  const accessNeedGroupIri = await discoverAccessNeeedGroup(applicationIri)
   if (!accessNeedGroupIri) return null;
-  const accessNeedGropupResponse = await fetch(accessNeedGroupIri)
-  const accessNeedGroup = await parseTurtle(await accessNeedGropupResponse.text(), accessNeedGropupResponse.url)
 
-  const descriptionSetIri = getOneObject(
-    accessNeedGroup.match(null, INTEROP.hasAccessDescriptionSet)
-  )?.value;
+  const accessNeedGroup = await AccessNeedGroup.build(accessNeedGroupIri, descriptionsLang)
+  if (!accessNeedGroup.accessDescriptionSet) return null;
 
-  if (!descriptionSetIri) return null;
-
-  const descriptionSetResponse = await fetch(descriptionSetIri)
-  const descriptionSet = await parseTurtle(await descriptionSetResponse.text(), descriptionSetResponse.url)
-  // TODO (angel) contemplate cases where the descriptions are spread across multiple locations
-  //              on the web. e.g.: .../desc-en.ttl, .../desc-es.ttl, etc.
-
-  const langs = [...descriptionSet.match(null, INTEROP.usesLanguage)].map(
-    (quad) => quad.object.value
-  );
-
-  if (!langs.includes(targetLang)) return null;
-
-  const targets = descriptionSet.match(null, INTEROP.inAccessDescriptionSet);
-
-  // TODO (angel) typings
-  const descriptions = [];
-  for (const target of targets) {
-    const descriptionTriples = descriptionSet.match(target.subject);
-
-    const id = target.subject.value;
-    const label = getOneObject(descriptionTriples.match(null, SKOS.prefLabel))?.value;
-    const description = getOneObject(descriptionTriples.match(null, SKOS.description))?.value;
-    let needId = getOneObject(descriptionTriples.match(null, INTEROP.hasAccessNeedGroup))?.value;
-    if (!needId)
-      needId = getOneObject(descriptionTriples.match(null, INTEROP.hasAccessNeed))?.value;
-
-    descriptions.push({ id, label, description, needId });
-  }
-  return descriptions;
+  return [
+    ...accessNeedGroup.accessDescriptionSet.accessNeedGroupDescriptions.map(desc => ({
+      id: desc.iri,
+      label: desc.label,
+      description: desc.definition,
+      needId: desc.accessNeedGroup
+    })),
+    ...accessNeedGroup.accessDescriptionSet.accessNeedDescriptions.map(desc => ({
+      id: desc.iri,
+      label: desc.label,
+      description: desc.definition,
+      needId: desc.accessNeed,
+      shapeTreeDescription: accessNeedGroup.getShapeTreeDescriptionForNeed(desc.accessNeed)
+    }))
+  ]
 };


### PR DESCRIPTION
Now descriptions will include descriptions from shape tree descriptions along with ones from access needs (and group).

I will create a separate issue to define the interface of the payload sent to the front end, for now we get (with current snippets):

```json
[
  {
    "id": "http://localhost:3000/acme/projectron/descriptions-en#en-need-group-pm",
    "label": "Read and Contribute to Projects",
    "description": "Allow Projectron to read the Projects you select, and create new ones. Projectron won't modify existing data, but can add more.",
    "needId": "http://localhost:3000/acme/projectron/access-needs#need-group-pm"
  },
  {
    "id": "http://localhost:3000/acme/projectron/descriptions-en#en-need-project",
    "label": "Access to Projects is essential for Projectron to perform its core function of Project Management",
    "needId": "http://localhost:3000/acme/projectron/access-needs#need-project",
    "shapeTreeDescription": {
      "label": "Projects"
    }
  },
  {
    "id": "http://localhost:3000/acme/projectron/descriptions-en#en-need-task",
    "label": "Access to Tasks allows Projectron to identify and manage the work to be done in a given Project.",
    "needId": "http://localhost:3000/acme/projectron/access-needs#need-task",
    "shapeTreeDescription": {
      "label": "Tasks"
    }
  }
]
```

Most logic will eventually be moved to sai-js!