### PR TITLE
Expose Link Headers to Clients

### DIFF
--- a/packages/service/config/common.json
+++ b/packages/service/config/common.json
@@ -14,6 +14,7 @@
         "@type": "NodeHttpRequestResponseHandler",
         "httpHandler": {
           "@type": "HttpCorsRequestHandler",
+          "options_exposeHeaders": ["Link"],
           "handler": {
             "@type": "ErrorHandler",
             "nestedHandler": {


### PR DESCRIPTION
The fetch API does not expose most headers by default. This change will expose the Link headers to clients.