### PR TITLE
Add unregistered application profile

### DIFF
--- a/packages/api-messages/src/index.ts
+++ b/packages/api-messages/src/index.ts
@@ -5,6 +5,7 @@ export const RequestMessageTypes = {
   DATA_REGISTRIES_REQUEST: '[DATA_REGISTRIES] Data Registries Requested',
   ADD_SOCIAL_AGENT_REQUEST: '[SOCIAL AGENTS] Data Registries Requested',
   APPLICATION_AUTHORIZATION: '[APPLICATION] Authorization submitted',
+  APPLICATION_PROFILE: 'ApplicationProfileRequest',
 } as const
 
 export const ResponseMessageTypes = {
@@ -14,13 +15,14 @@ export const ResponseMessageTypes = {
   DATA_REGISTRIES_RESPONSE: '[DATA_REGISTRIES] Data Registries Received',
   SOCIAL_AGENT_RESPONSE: '[SOCIAL AGENTS] Social Agent Received',
   APPLICATION_AUTHORIZATION_REGISTERED: '[APPLICATION] Authorization registered',
+  APPLICATION_PROFILE: 'ApplicationProfileResponse',
 } as const
 
 type TResponseMessage = typeof ResponseMessageTypes
 
-type TResponseMesssages = keyof TResponseMessage
+type TResponseMessages = keyof TResponseMessage
 
-type VResponseMessages = TResponseMessage[TResponseMesssages]
+type VResponseMessages = TResponseMessage[TResponseMessages]
 
 // type ResponseKeys = keyof typeof ResponseMessageTypes
 

--- a/packages/service/src/handlers/api-handler.ts
+++ b/packages/service/src/handlers/api-handler.ts
@@ -3,8 +3,10 @@ import { BadRequestHttpError, HttpHandler, HttpHandlerResponse } from "@digita-a
 import { getLoggerFor } from '@digita-ai/handlersjs-logging';
 import { RequestMessageTypes, ResponseMessageTypes } from "@janeirodigital/sai-api-messages";
 import type { IQueue } from "@janeirodigital/sai-server-interfaces";
-import { getApplications, getDescriptions, recordAuthorization,
-  getDataRegistries, getSocialAgents, addSocialAgent } from "../services";
+import {
+  getApplications, getDescriptions, recordAuthorization,
+  getDataRegistries, getSocialAgents, addSocialAgent, getUnregisteredApplicationProfile
+} from '../services';
 import type { SaiContext } from "../models/http-solid-context";
 import { validateContentType } from "../utils/http-validators";
 import { IReciprocalRegistrationsJobData } from "../models/jobs";
@@ -32,6 +34,13 @@ export class ApiHandler extends HttpHandler {
           type: ResponseMessageTypes.APPLICATIONS_RESPONSE,
           payload: await getApplications(context.saiSession)
         }, status: 200, headers: {} }
+      case RequestMessageTypes.APPLICATION_PROFILE:
+        // eslint-disable-next-line no-case-declarations
+        const { id } = body;
+        return { body: {
+          type: ResponseMessageTypes.APPLICATION_PROFILE,
+          payload: await getUnregisteredApplicationProfile(context.saiSession, id),
+          }, status: 200, headers: {} }
       case RequestMessageTypes.SOCIAL_AGENTS_REQUEST:
         return { body: {
           type: ResponseMessageTypes.SOCIAL_AGENTS_RESPONSE,

--- a/packages/service/src/services/applications.ts
+++ b/packages/service/src/services/applications.ts
@@ -1,6 +1,6 @@
 import type { CRUDApplicationRegistration } from "@janeirodigital/interop-data-model";
 import type { AuthorizationAgent } from "@janeirodigital/interop-authorization-agent";
-import type { Application } from "@janeirodigital/sai-api-messages";
+import type { Application, IRI } from '@janeirodigital/sai-api-messages';
 
 const buildApplicationProfile = (
   registration: CRUDApplicationRegistration
@@ -23,3 +23,11 @@ export const getApplications = async (saiSession: AuthorizationAgent) => {
   }
   return profiles;
 };
+
+export const getUnregisteredApplicationProfile = async (agent: AuthorizationAgent, id: IRI): Promise<Partial<Application>> => {
+  const {name, logo, accessNeedGroup } = await agent.factory.readable.clientIdDocument(id).then(doc => (
+    { name: doc.clientName, logo: doc.logoUri, accessNeedGroup: doc.hasAccessNeedGroup }
+  ));
+
+  return { name, logo, accessNeedGroup };
+}

--- a/packages/service/test/unit/services/applications-test.ts
+++ b/packages/service/test/unit/services/applications-test.ts
@@ -1,5 +1,5 @@
 import type { AuthorizationAgent } from '@janeirodigital/interop-authorization-agent'
-import { getApplications } from '../../../src/services/applications'
+import { getApplications, getUnregisteredApplicationProfile } from '../../../src/services/applications';
 
 const saiSession = {
   applicationRegistrations: [
@@ -40,3 +40,20 @@ test('formats correctly', async () => {
     }
   ]))
 })
+
+test('get unregistered application profile', async () => {
+  const agent = {
+    factory: {
+      readable: {
+        clientIdDocument: () => Promise.resolve(
+          {clientName: 'name', logoUri: 'http://logo', hasAccessNeedGroup: 'http://group'}
+        ),
+      }
+    }
+  } as unknown as AuthorizationAgent;
+
+  const profile = await getUnregisteredApplicationProfile(agent, "http://id")
+  expect(profile.name).toEqual('name');
+  expect(profile.logo).toEqual('http://logo');
+  expect(profile.accessNeedGroup).toEqual('http://group');
+});


### PR DESCRIPTION
Add endpoint to provide the application name and logo_uri for any application, given its client_id IRI.

Depends on janeirodigital/sai-js#48